### PR TITLE
Update SBCL and CCL

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,15 @@ A Buildpack that allows you to deploy Common Lisp applications on the Heroku inf
 
 Original work by Mike Travers, mt@hyperphor.com
 
-## Changes 
+## Changes in this fork
+
+* Updated SBCL and Clozure CL binary distributions (1.5.1 and 1.11.5, respectively)
+
+> Admittedly, I know nothing about getting machines to download from SourceForge,
+but as long as the JAIST mirror is around, this should work fine.
+
+## Changes (by jsmpereira)
+
 * Support for SBCL and Hunchentoot.
 
 > Example app at https://github.com/jsmpereira/heroku-cl-example

--- a/bin/compile
+++ b/bin/compile
@@ -42,15 +42,14 @@ echo "-----> CL_IMPL: $CL_IMPL"
 
 case $CL_IMPL in
   sbcl)
-    S3_BUCKET="sbcl-heroku"
-    CL_PACKAGE="https://s3.amazonaws.com/${S3_BUCKET}/sbcl-1.2.13-x86-64-linux-binary.tar.bz2"
-    DECOMPRESS="tar jxvf - -C $CL_DIR"
+    CL_PACKAGE="https://jaist.dl.sourceforge.net/project/sbcl/sbcl/1.5.1/sbcl-1.5.1-x86-64-linux-binary.tar.bz2"
+    DECOMPRESS="tar jzf - -C $CL_DIR"
     ;;
   ccl)
     S3_BUCKET="cl-heroku"
-    CL_PACKAGE="http://${S3_BUCKET}.s3.amazonaws.com/ccl-1.7.tgz"
+    CL_PACKAGE="https://github.com/Clozure/ccl/releases/download/v1.11.5/ccl-1.11.5-linuxx86.tar.gz"
     DECOMPRESS="tar xzf - -C $CL_DIR"
-    export CCL_DEFAULT_DIRECTORY=$CL_DIR # overwrite CCL_DEFAULT_DIRECTORY on ccl64
+    export CCL_DEFAULT_DIRECTORY=$CL_DIR/ccl # overwrite CCL_DEFAULT_DIRECTORY on ccl64
     ;;
   *)
     echo "-----> ! Please set CL_IMPL: heroku config:add CL_IMPL={sbcl|ccl}."
@@ -111,7 +110,7 @@ export BUILD_DIR
 
 echo "-----> Starting build"
 case $CL_IMPL in
-  sbcl) sh $CL_DIR/sbcl-1.2.13-x86-64-linux/run-sbcl.sh --load "$BUILDPACK_DIR/setup/compile.lisp";;
+  sbcl) sh $CL_DIR/sbcl-1.5.1-x86-64-linux/run-sbcl.sh --load "$BUILDPACK_DIR/setup/compile.lisp";;
   ccl) $CCL_DEFAULT_DIRECTORY/scripts/ccl64 -l "$BUILDPACK_DIR/setup/compile.lisp";;
 esac
 echo "-----> Build finished"

--- a/bin/compile
+++ b/bin/compile
@@ -43,7 +43,7 @@ echo "-----> CL_IMPL: $CL_IMPL"
 case $CL_IMPL in
   sbcl)
     CL_PACKAGE="https://jaist.dl.sourceforge.net/project/sbcl/sbcl/1.5.1/sbcl-1.5.1-x86-64-linux-binary.tar.bz2"
-    DECOMPRESS="tar jzf - -C $CL_DIR"
+    DECOMPRESS="tar jxf - -C $CL_DIR"
     ;;
   ccl)
     S3_BUCKET="cl-heroku"


### PR DESCRIPTION
Well, SBCL and CCL have had many updates and many libraries refuse to load (like websocket-driver) due to dependencies that are broken on these old versions, such as UIOP. This PR just updates them, by pulling them from the SBCL Sourceforge repository, and the CCL GitHub release. I don't believe this changes anything else unless client programs used version-specific non-portable functions.